### PR TITLE
New build structure

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 .nyc_output
 .vscode
-dist
+build
 node_modules
 reports
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .nyc_output
 .vscode
-dist
+build
 docs
 node_modules
 reports

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 .nyc_output
 .vscode
-dist
+build
 node_modules
 reports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "af-utilities",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "af-conditionals": "^1.2.0",
@@ -29,6 +29,7 @@
         "mochawesome": "^6.1.0",
         "nyc": "^15.0.1",
         "prettier": "^2.2.1",
+        "rimraf": "^3.0.2",
         "sinon": "^9.0.2",
         "source-map-support": "^0.5.18",
         "ts-node": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
   "main": "dist/lib/index.js",
   "scripts": {
-    "clean-dist": "rm -rf dist",
-    "clean-reports": "rm -rf reports && rm -rf .nyc_output",
+    "clean-dist": "npx rimraf dist",
+    "clean-reports": "npx rimraf reports && npx rimraf .nyc_output",
     "clean-all": "npm run clean-dist && npm run clean-reports",
     "compile": "./node_modules/.bin/tsc",
     "dist": "npm run clean-all && npm test && npm run compile",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "mochawesome": "^6.1.0",
     "nyc": "^15.0.1",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "sinon": "^9.0.2",
     "source-map-support": "^0.5.18",
     "ts-node": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,20 @@
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
   "main": "build/lib/index.js",
   "scripts": {
+    "build": "npm run clean:all && npm test && npm run compile",
     "clean:build": "npx rimraf build",
     "clean-dist": "npm run clean:build",
     "clean:reports": "npx rimraf reports && npx rimraf .nyc_output",
     "clean-reports": "npm run clean:reports",
     "clean:all": "npm run clean:build && npm run clean:reports",
     "clean-all": "npm run clean:all",
-    "compile": " npx tsc",
-    "build": "npm run clean:all && npm test && npm run compile",
+    "compile": "npx tsc",
+    "coverage": "npx nyc report --reporter=text-lcov | coveralls",
     "dist": "npm run build",
-    "test": "npx nyc mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'",
-    "coverage": "npx nyc report --reporter=text-lcov | coveralls"
+    "fix": "npx eslint --fix '**/*.ts'",
+    "format": "npx prettier --write .",
+    "lint": "npx eslint '**/*.ts'",
+    "test": "npx nyc mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'"
   },
   "files": [
     "build"

--- a/package.json
+++ b/package.json
@@ -2,21 +2,22 @@
   "name": "af-utilities",
   "version": "1.3.0",
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
-  "main": "dist/lib/index.js",
+  "main": "build/lib/index.js",
   "scripts": {
-    "clean:dist": "npx rimraf dist",
-    "clean-dist": "npm run clean:dist",
+    "clean:build": "npx rimraf build",
+    "clean-dist": "npm run clean:build",
     "clean:reports": "npx rimraf reports && npx rimraf .nyc_output",
     "clean-reports": "npm run clean:reports",
-    "clean:all": "npm run clean:dist && npm run clean:reports",
+    "clean:all": "npm run clean:build && npm run clean:reports",
     "clean-all": "npm run clean:all",
     "compile": " npx tsc",
-    "dist": "npm run clean:all && npm test && npm run compile",
+    "build": "npm run clean:all && npm test && npm run compile",
+    "dist": "npm run build",
     "test": "npx nyc mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'",
     "coverage": "npx nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
-    "dist"
+    "build"
   ],
   "nyc": {
     "include": [

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Utility functions used within the af-XXXX Frameworks and Libraries",
   "main": "dist/lib/index.js",
   "scripts": {
-    "clean-dist": "npx rimraf dist",
-    "clean-reports": "npx rimraf reports && npx rimraf .nyc_output",
-    "clean-all": "npm run clean-dist && npm run clean-reports",
+    "clean:dist": "npx rimraf dist",
+    "clean-dist": "npm run clean:dist",
+    "clean:reports": "npx rimraf reports && npx rimraf .nyc_output",
+    "clean-reports": "npm run clean:reports",
+    "clean:all": "npm run clean:dist && npm run clean:reports",
+    "clean-all": "npm run clean:all",
     "compile": " npx tsc",
-    "dist": "npm run clean-all && npm test && npm run compile",
+    "dist": "npm run clean:all && npm test && npm run compile",
     "test": "npx nyc mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'",
     "coverage": "npx nyc report --reporter=text-lcov | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "clean-dist": "npx rimraf dist",
     "clean-reports": "npx rimraf reports && npx rimraf .nyc_output",
     "clean-all": "npm run clean-dist && npm run clean-reports",
-    "compile": "./node_modules/.bin/tsc",
+    "compile": " npx tsc",
     "dist": "npm run clean-all && npm test && npm run compile",
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'",
-    "coverage": "./node_modules/.bin/nyc report --reporter=text-lcov | coveralls"
+    "test": "npx nyc mocha --config ./test/.mocharc.json --reporter-options reportDir='./reports/testing'",
+    "coverage": "npx nyc report --reporter=text-lcov | coveralls"
   },
   "files": [
     "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "lib": ["ES2018"],
+    "target": "ES2018",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "declaration": true,
     "sourceMap": true,
     "removeComments": true,
-    "outDir": "./dist/",
+    "outDir": "./build/",
     "rootDir": "./src",
 
     "downlevelIteration": true,


### PR DESCRIPTION
- Update the build structure of this package to use `build` folder  instead of `dist`
- Introduce standards created for [codemgr](https://github.com/acmeframework/codemgr)
- Add `rimraf` as a development dependency

